### PR TITLE
AWN-68514 - GitHub Advanced Security Automation[bot]

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,30 @@
+################
+# DO NOT EDIT! #
+################
+# This file is maintained by https://github.com/rtkwlf/devsecops-gh-automation
+# making any changes here will prompt a new PR to
+# be opened against your repository.
+# Please reach out to DevSecOps with questions, comments, or issues.
+# https://arcticwolf.atlassian.net/wiki/spaces/AWD/pages/2912944394/Engaging+the+DevSecOps+team
+version: 2
+# Define the registry for the rtkwlf-actions GitHub Org
+registries:
+  github-rtkwlf-actions:
+    type: git
+    url: https://github.com
+    username: rtkdependabot
+    password: ${{ secrets.RTKWLF_ACTIONS_PAT }}
+
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - github-actions
+      - patch release
+    registries:
+      - github-rtkwlf-actions

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,0 +1,46 @@
+##########################################
+# DO NOT EDIT THE CODEQL INIT LANGUAGES! #
+##########################################
+# This file is maintained by https://github.com/rtkwlf/devsecops-gh-automation,
+# making any changes to the codeql init step will prompt a new PR to
+# be opened against your repository. Otherwise feel free to customize.
+# Please reach out to DevSecOps if there are any questions, concerns, or to report any errors.
+# https://arcticwolf.atlassian.net/wiki/spaces/AWD/pages/2912944394/Engaging+the+DevSecOps+team
+name: codeql-security-analysis
+on:
+  push:
+    branches:
+      - dev
+      - develop
+      - main
+      - master
+  pull_request:
+    branches:
+      - dev
+      - develop
+      - main
+      - master
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  codeql-security-analysis:
+    runs-on: ubuntu-20.04
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+
+      - name: initialize codeql
+        uses: github/codeql-action/init@v2
+        with:
+          languages: c, cpp, csharp, java, Python
+          queries: security-extended
+
+      - name: perform codeql analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/dependabot-ticketer.yaml
+++ b/.github/workflows/dependabot-ticketer.yaml
@@ -1,0 +1,87 @@
+################
+# DO NOT EDIT! #
+################
+# This file is maintained by DevSecOps automation,
+# making any changes here will prompt a new PR to
+# be opened against your repository.
+# Please reach out to DevSecOps if there are any questions, concerns, or to report any errors.
+# https://arcticwolf.atlassian.net/wiki/spaces/AWD/pages/2912944394/Engaging+the+DevSecOps+team
+name: dependabot workflow
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
+
+jobs:
+  dependabot-ticketer:
+    runs-on: ubuntu-20.04
+    if: github.actor == 'dependabot[bot]'
+    env:
+      JIRA_API_TOKEN: ${{ secrets.PAT_RTKWLF_DEVSECOPS_TICKETER }}
+      JIRA_BASE_URL: ${{ secrets.RTKWLF_JIRA_BASE_URL }}
+      JIRA_ISSUE_TYPE: R&D Security Finding
+      JIRA_PROJECT: AWN
+      JIRA_RND_TEAM: ''
+      JIRA_USER_EMAIL: ${{ secrets.RTKWLF_DEVSECOPS_TICKETER_EMAIL }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Dependabots Original PR Title
+        id: dependabot-title
+        run: echo ::set-output name=DBOT_TITLE::"$(gh pr view --json title "$PR_URL" -q .title)"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: login to jira
+        uses: atlassian/gajira-login@v2.0.0
+        env:
+          JIRA_API_TOKEN: ${{ env.JIRA_API_TOKEN }}
+          JIRA_BASE_URL: ${{ env.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ env.JIRA_USER_EMAIL }}
+
+      - name: create jira issue
+        id: create
+        uses: atlassian/gajira-create@v2.0.1
+        with:
+          project: ${{ env.JIRA_PROJECT }}
+          issuetype: ${{ env.JIRA_ISSUE_TYPE }}
+          summary: |
+            [Dependabot] - ${{ github.event.repository.name }} - ${{ steps.dependabot-title.outputs.DBOT_TITLE }}
+          description: |
+            GitHub PR: ${{ github.event.repository.html_url }}/pull/${{ github.event.workflow_run.pull_requests[0].number }}
+            Package Type: ${{ steps.metadata.outputs.package-ecosystem }}
+          # The gajira-create module explicity uses json in the YAML configuration
+          fields: |
+            {
+                "customfield_10700": {
+                    "value": "${{ env.JIRA_RND_TEAM }}"
+                },
+                "customfield_12980": "Dependabot",
+                "labels": [
+                    "source:dbot_ticketer",
+                    "pkgman:${{ steps.metadata.outputs.package-ecosystem }}",
+                    "org:${{ github.repository_owner }}"
+                ]
+            }
+
+      - name: Add Jira ticket URL to PR
+        run: gh pr edit "$PR_URL" --title "${{ steps.create.outputs.issue }} - ${{ steps.dependabot-title.outputs.DBOT_TITLE }}"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add patch release label
+        run: gh pr edit "$PR_URL" --add-label "patch release"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ghas-scribe.yaml
+++ b/.github/workflows/ghas-scribe.yaml
@@ -1,0 +1,17 @@
+name: check for ghas security alerts
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  scribe:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: ticket security alerts
+        uses: rtkwlf-actions/ghas-security-scribe@v1.0.1
+        with:
+          github_alert_token: ${{ secrets.ALERT_SCANNING_INSTALLATION_ACCESS_TOKEN }}
+          jira_api_token: ${{ secrets.PAT_RTKWLF_DEVSECOPS_TICKETER }}
+          jira_user: ${{ secrets.RTKWLF_DEVSECOPS_TICKETER_EMAIL }}
+          jira_rnd_team: None


### PR DESCRIPTION
# Why am I getting this PR?
This PR was opened by the devsecops-gh-automation repository. The automation from this repository will run
once every 24 hours, to ensure repositories are staying up-to-date, removing the need for developers to
have to maintain their GitHub Advanced Security configurations. For more information, please read our 
[DORY](https://arcticwolf.atlassian.net/wiki/spaces/PD/pages/2912649537/GitHub+Advanced+Security+GHAS+and+Dory+Cyclops) documentation.

## Action Items

- [ ] Ensure [Jira R&D Team](.github/workflows/dependabot-ticketer.yaml?plain=1#32) is filled out (only necessary on first PR or when updating the team receiving tickets)
- [ ] Review PR to confirm it's accuracy

### CHANGES
- Add rtkwlf-actions org private registry to dependabot.yaml (04-21-22) @AWNCypher
